### PR TITLE
Added presets to allow the use of the APC mini mk2 midi controllers with Iverson and Iverson Jr

### DIFF
--- a/presets/Iverson/Iverson_APC_mini_mk2.vcvm
+++ b/presets/Iverson/Iverson_APC_mini_mk2.vcvm
@@ -1,0 +1,1761 @@
+{
+  "plugin": "StudioSixPlusOne",
+  "model": "Iverson",
+  "version": "2.1.00",
+  "params": [
+    {
+      "value": 0.0,
+      "id": 0
+    },
+    {
+      "value": 0.0,
+      "id": 1
+    },
+    {
+      "value": 0.0,
+      "id": 2
+    },
+    {
+      "value": 0.0,
+      "id": 3
+    },
+    {
+      "value": 0.0,
+      "id": 4
+    },
+    {
+      "value": 0.0,
+      "id": 5
+    },
+    {
+      "value": 0.0,
+      "id": 6
+    },
+    {
+      "value": 0.0,
+      "id": 7
+    },
+    {
+      "value": 0.0,
+      "id": 8
+    },
+    {
+      "value": 0.0,
+      "id": 9
+    },
+    {
+      "value": 0.0,
+      "id": 10
+    },
+    {
+      "value": 0.0,
+      "id": 11
+    },
+    {
+      "value": 0.0,
+      "id": 12
+    },
+    {
+      "value": 0.0,
+      "id": 13
+    },
+    {
+      "value": 0.0,
+      "id": 14
+    },
+    {
+      "value": 0.0,
+      "id": 15
+    },
+    {
+      "value": 0.0,
+      "id": 16
+    },
+    {
+      "value": 0.0,
+      "id": 17
+    },
+    {
+      "value": 0.0,
+      "id": 18
+    },
+    {
+      "value": 0.0,
+      "id": 19
+    },
+    {
+      "value": 0.0,
+      "id": 20
+    },
+    {
+      "value": 0.0,
+      "id": 21
+    },
+    {
+      "value": 0.0,
+      "id": 22
+    },
+    {
+      "value": 0.0,
+      "id": 23
+    },
+    {
+      "value": 0.0,
+      "id": 24
+    },
+    {
+      "value": 0.0,
+      "id": 25
+    },
+    {
+      "value": 0.0,
+      "id": 26
+    },
+    {
+      "value": 0.0,
+      "id": 27
+    },
+    {
+      "value": 0.0,
+      "id": 28
+    },
+    {
+      "value": 0.0,
+      "id": 29
+    },
+    {
+      "value": 0.0,
+      "id": 30
+    },
+    {
+      "value": 0.0,
+      "id": 31
+    },
+    {
+      "value": 0.0,
+      "id": 32
+    },
+    {
+      "value": 0.0,
+      "id": 33
+    },
+    {
+      "value": 0.0,
+      "id": 34
+    },
+    {
+      "value": 0.0,
+      "id": 35
+    },
+    {
+      "value": 0.0,
+      "id": 36
+    },
+    {
+      "value": 0.0,
+      "id": 37
+    },
+    {
+      "value": 0.0,
+      "id": 38
+    },
+    {
+      "value": 0.0,
+      "id": 39
+    },
+    {
+      "value": 0.0,
+      "id": 40
+    },
+    {
+      "value": 0.0,
+      "id": 41
+    },
+    {
+      "value": 0.0,
+      "id": 42
+    },
+    {
+      "value": 0.0,
+      "id": 43
+    },
+    {
+      "value": 0.0,
+      "id": 44
+    },
+    {
+      "value": 0.0,
+      "id": 45
+    },
+    {
+      "value": 0.0,
+      "id": 46
+    },
+    {
+      "value": 0.0,
+      "id": 47
+    },
+    {
+      "value": 0.0,
+      "id": 48
+    },
+    {
+      "value": 0.0,
+      "id": 49
+    },
+    {
+      "value": 0.0,
+      "id": 50
+    },
+    {
+      "value": 0.0,
+      "id": 51
+    },
+    {
+      "value": 0.0,
+      "id": 52
+    },
+    {
+      "value": 0.0,
+      "id": 53
+    },
+    {
+      "value": 0.0,
+      "id": 54
+    },
+    {
+      "value": 0.0,
+      "id": 55
+    },
+    {
+      "value": 0.0,
+      "id": 56
+    },
+    {
+      "value": 0.0,
+      "id": 57
+    },
+    {
+      "value": 0.0,
+      "id": 58
+    },
+    {
+      "value": 0.0,
+      "id": 59
+    },
+    {
+      "value": 0.0,
+      "id": 60
+    },
+    {
+      "value": 0.0,
+      "id": 61
+    },
+    {
+      "value": 0.0,
+      "id": 62
+    },
+    {
+      "value": 0.0,
+      "id": 63
+    },
+    {
+      "value": 0.0,
+      "id": 64
+    },
+    {
+      "value": 0.0,
+      "id": 65
+    },
+    {
+      "value": 0.0,
+      "id": 66
+    },
+    {
+      "value": 0.0,
+      "id": 67
+    },
+    {
+      "value": 0.0,
+      "id": 68
+    },
+    {
+      "value": 0.0,
+      "id": 69
+    },
+    {
+      "value": 0.0,
+      "id": 70
+    },
+    {
+      "value": 0.0,
+      "id": 71
+    },
+    {
+      "value": 0.0,
+      "id": 72
+    },
+    {
+      "value": 0.0,
+      "id": 73
+    },
+    {
+      "value": 0.0,
+      "id": 74
+    },
+    {
+      "value": 0.0,
+      "id": 75
+    },
+    {
+      "value": 0.0,
+      "id": 76
+    },
+    {
+      "value": 0.0,
+      "id": 77
+    },
+    {
+      "value": 0.0,
+      "id": 78
+    },
+    {
+      "value": 0.0,
+      "id": 79
+    },
+    {
+      "value": 0.0,
+      "id": 80
+    },
+    {
+      "value": 0.0,
+      "id": 81
+    },
+    {
+      "value": 0.0,
+      "id": 82
+    },
+    {
+      "value": 0.0,
+      "id": 83
+    },
+    {
+      "value": 0.0,
+      "id": 84
+    },
+    {
+      "value": 0.0,
+      "id": 85
+    },
+    {
+      "value": 0.0,
+      "id": 86
+    },
+    {
+      "value": 0.0,
+      "id": 87
+    },
+    {
+      "value": 0.0,
+      "id": 88
+    },
+    {
+      "value": 0.0,
+      "id": 89
+    },
+    {
+      "value": 0.0,
+      "id": 90
+    },
+    {
+      "value": 0.0,
+      "id": 91
+    },
+    {
+      "value": 0.0,
+      "id": 92
+    },
+    {
+      "value": 0.0,
+      "id": 93
+    },
+    {
+      "value": 0.0,
+      "id": 94
+    },
+    {
+      "value": 0.0,
+      "id": 95
+    },
+    {
+      "value": 0.0,
+      "id": 96
+    },
+    {
+      "value": 0.0,
+      "id": 97
+    },
+    {
+      "value": 0.0,
+      "id": 98
+    },
+    {
+      "value": 0.0,
+      "id": 99
+    },
+    {
+      "value": 0.0,
+      "id": 100
+    },
+    {
+      "value": 0.0,
+      "id": 101
+    },
+    {
+      "value": 0.0,
+      "id": 102
+    },
+    {
+      "value": 0.0,
+      "id": 103
+    },
+    {
+      "value": 0.0,
+      "id": 104
+    },
+    {
+      "value": 0.0,
+      "id": 105
+    },
+    {
+      "value": 0.0,
+      "id": 106
+    },
+    {
+      "value": 0.0,
+      "id": 107
+    },
+    {
+      "value": 0.0,
+      "id": 108
+    },
+    {
+      "value": 0.0,
+      "id": 109
+    },
+    {
+      "value": 0.0,
+      "id": 110
+    },
+    {
+      "value": 0.0,
+      "id": 111
+    },
+    {
+      "value": 0.0,
+      "id": 112
+    },
+    {
+      "value": 0.0,
+      "id": 113
+    },
+    {
+      "value": 0.0,
+      "id": 114
+    },
+    {
+      "value": 0.0,
+      "id": 115
+    },
+    {
+      "value": 0.0,
+      "id": 116
+    },
+    {
+      "value": 0.0,
+      "id": 117
+    },
+    {
+      "value": 0.0,
+      "id": 118
+    },
+    {
+      "value": 0.0,
+      "id": 119
+    },
+    {
+      "value": 0.0,
+      "id": 120
+    },
+    {
+      "value": 0.0,
+      "id": 121
+    },
+    {
+      "value": 0.0,
+      "id": 122
+    },
+    {
+      "value": 0.0,
+      "id": 123
+    },
+    {
+      "value": 0.0,
+      "id": 124
+    },
+    {
+      "value": 0.0,
+      "id": 125
+    },
+    {
+      "value": 0.0,
+      "id": 126
+    },
+    {
+      "value": 0.0,
+      "id": 127
+    },
+    {
+      "value": 0.0,
+      "id": 128
+    },
+    {
+      "value": 0.0,
+      "id": 129
+    },
+    {
+      "value": 0.0,
+      "id": 130
+    },
+    {
+      "value": 0.0,
+      "id": 131
+    },
+    {
+      "value": 0.0,
+      "id": 132
+    },
+    {
+      "value": 0.0,
+      "id": 133
+    },
+    {
+      "value": 0.0,
+      "id": 134
+    },
+    {
+      "value": 0.0,
+      "id": 135
+    },
+    {
+      "value": 16.0,
+      "id": 136
+    },
+    {
+      "value": 16.0,
+      "id": 137
+    },
+    {
+      "value": 16.0,
+      "id": 138
+    },
+    {
+      "value": 16.0,
+      "id": 139
+    },
+    {
+      "value": 16.0,
+      "id": 140
+    },
+    {
+      "value": 16.0,
+      "id": 141
+    },
+    {
+      "value": 16.0,
+      "id": 142
+    },
+    {
+      "value": 16.0,
+      "id": 143
+    },
+    {
+      "value": 0.0,
+      "id": 144
+    },
+    {
+      "value": 0.0,
+      "id": 145
+    },
+    {
+      "value": 0.0,
+      "id": 146
+    },
+    {
+      "value": 0.0,
+      "id": 147
+    },
+    {
+      "value": 0.0,
+      "id": 148
+    },
+    {
+      "value": 0.0,
+      "id": 149
+    },
+    {
+      "value": 0.0,
+      "id": 150
+    },
+    {
+      "value": 0.0,
+      "id": 151
+    },
+    {
+      "value": 1.0,
+      "id": 152
+    },
+    {
+      "value": 1.0,
+      "id": 153
+    },
+    {
+      "value": 0.96062994003295898,
+      "id": 154
+    },
+    {
+      "value": 1.0,
+      "id": 155
+    },
+    {
+      "value": 1.0,
+      "id": 156
+    },
+    {
+      "value": 1.0,
+      "id": 157
+    },
+    {
+      "value": 1.0,
+      "id": 158
+    },
+    {
+      "value": 0.91338580846786499,
+      "id": 159
+    },
+    {
+      "value": 1.0,
+      "id": 160
+    },
+    {
+      "value": 1.0,
+      "id": 161
+    },
+    {
+      "value": 1.0,
+      "id": 162
+    },
+    {
+      "value": 1.0,
+      "id": 163
+    },
+    {
+      "value": 1.0,
+      "id": 164
+    },
+    {
+      "value": 1.0,
+      "id": 165
+    },
+    {
+      "value": 1.0,
+      "id": 166
+    },
+    {
+      "value": 1.0,
+      "id": 167
+    },
+    {
+      "value": 0.0,
+      "id": 168
+    },
+    {
+      "value": 0.0,
+      "id": 169
+    },
+    {
+      "value": 0.0,
+      "id": 170
+    },
+    {
+      "value": 21.0,
+      "id": 171
+    },
+    {
+      "value": 5.0,
+      "id": 172
+    },
+    {
+      "value": 5.0,
+      "id": 173
+    },
+    {
+      "value": 96.0,
+      "id": 174
+    },
+    {
+      "value": 0.0,
+      "id": 175
+    },
+    {
+      "value": 0.0,
+      "id": 176
+    },
+    {
+      "value": 0.0,
+      "id": 177
+    },
+    {
+      "value": 0.0,
+      "id": 178
+    }
+  ],
+  "data": {
+    "actives": [
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true
+    ],
+    "lengths": [
+      16,
+      16,
+      16,
+      16,
+      16,
+      16,
+      16,
+      16
+    ],
+    "index": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "sequenceHi": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "sequenceLow": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "midiBinding": [
+      {
+        "controller": 0,
+        "note": 100,
+        "cc": -1,
+        "paramId": 144
+      },
+      {
+        "controller": 0,
+        "note": 101,
+        "cc": -1,
+        "paramId": 145
+      },
+      {
+        "controller": 0,
+        "note": 102,
+        "cc": -1,
+        "paramId": 146
+      },
+      {
+        "controller": 0,
+        "note": 103,
+        "cc": -1,
+        "paramId": 147
+      },
+      {
+        "controller": 0,
+        "note": 104,
+        "cc": -1,
+        "paramId": 150
+      },
+      {
+        "controller": 0,
+        "note": 105,
+        "cc": -1,
+        "paramId": 148
+      },
+      {
+        "controller": 0,
+        "note": 106,
+        "cc": -1,
+        "paramId": 149
+      },
+      {
+        "controller": 0,
+        "note": 107,
+        "cc": -1,
+        "paramId": 177
+      },
+      {
+        "controller": 0,
+        "note": 122,
+        "cc": -1,
+        "paramId": 176
+      },
+      {
+        "controller": 0,
+        "note": -1,
+        "cc": 48,
+        "paramId": 152
+      },
+      {
+        "controller": 0,
+        "note": -1,
+        "cc": 49,
+        "paramId": 153
+      },
+      {
+        "controller": 0,
+        "note": -1,
+        "cc": 50,
+        "paramId": 154
+      },
+      {
+        "controller": 0,
+        "note": -1,
+        "cc": 51,
+        "paramId": 155
+      },
+      {
+        "controller": 0,
+        "note": -1,
+        "cc": 52,
+        "paramId": 156
+      },
+      {
+        "controller": 0,
+        "note": -1,
+        "cc": 53,
+        "paramId": 157
+      },
+      {
+        "controller": 0,
+        "note": -1,
+        "cc": 54,
+        "paramId": 158
+      },
+      {
+        "controller": 0,
+        "note": -1,
+        "cc": 55,
+        "paramId": 159
+      },
+      {
+        "controller": 0,
+        "note": 56,
+        "cc": -1,
+        "paramId": 0
+      },
+      {
+        "controller": 0,
+        "note": 57,
+        "cc": -1,
+        "paramId": 1
+      },
+      {
+        "controller": 0,
+        "note": 58,
+        "cc": -1,
+        "paramId": 2
+      },
+      {
+        "controller": 0,
+        "note": 59,
+        "cc": -1,
+        "paramId": 3
+      },
+      {
+        "controller": 0,
+        "note": 60,
+        "cc": -1,
+        "paramId": 4
+      },
+      {
+        "controller": 0,
+        "note": 61,
+        "cc": -1,
+        "paramId": 5
+      },
+      {
+        "controller": 0,
+        "note": 62,
+        "cc": -1,
+        "paramId": 6
+      },
+      {
+        "controller": 0,
+        "note": 63,
+        "cc": -1,
+        "paramId": 7
+      },
+      {
+        "controller": 0,
+        "note": 48,
+        "cc": -1,
+        "paramId": 16
+      },
+      {
+        "controller": 0,
+        "note": 49,
+        "cc": -1,
+        "paramId": 17
+      },
+      {
+        "controller": 0,
+        "note": 50,
+        "cc": -1,
+        "paramId": 18
+      },
+      {
+        "controller": 0,
+        "note": 51,
+        "cc": -1,
+        "paramId": 19
+      },
+      {
+        "controller": 0,
+        "note": 52,
+        "cc": -1,
+        "paramId": 20
+      },
+      {
+        "controller": 0,
+        "note": 53,
+        "cc": -1,
+        "paramId": 21
+      },
+      {
+        "controller": 0,
+        "note": 54,
+        "cc": -1,
+        "paramId": 22
+      },
+      {
+        "controller": 0,
+        "note": 55,
+        "cc": -1,
+        "paramId": 23
+      },
+      {
+        "controller": 0,
+        "note": 40,
+        "cc": -1,
+        "paramId": 32
+      },
+      {
+        "controller": 0,
+        "note": 41,
+        "cc": -1,
+        "paramId": 33
+      },
+      {
+        "controller": 0,
+        "note": 42,
+        "cc": -1,
+        "paramId": 34
+      },
+      {
+        "controller": 0,
+        "note": 43,
+        "cc": -1,
+        "paramId": 35
+      },
+      {
+        "controller": 0,
+        "note": 44,
+        "cc": -1,
+        "paramId": 36
+      },
+      {
+        "controller": 0,
+        "note": 45,
+        "cc": -1,
+        "paramId": 37
+      },
+      {
+        "controller": 0,
+        "note": 46,
+        "cc": -1,
+        "paramId": 38
+      },
+      {
+        "controller": 0,
+        "note": 47,
+        "cc": -1,
+        "paramId": 39
+      },
+      {
+        "controller": 0,
+        "note": 32,
+        "cc": -1,
+        "paramId": 48
+      },
+      {
+        "controller": 0,
+        "note": 33,
+        "cc": -1,
+        "paramId": 49
+      },
+      {
+        "controller": 0,
+        "note": 34,
+        "cc": -1,
+        "paramId": 50
+      },
+      {
+        "controller": 0,
+        "note": 35,
+        "cc": -1,
+        "paramId": 51
+      },
+      {
+        "controller": 0,
+        "note": 36,
+        "cc": -1,
+        "paramId": 52
+      },
+      {
+        "controller": 0,
+        "note": 37,
+        "cc": -1,
+        "paramId": 53
+      },
+      {
+        "controller": 0,
+        "note": 38,
+        "cc": -1,
+        "paramId": 54
+      },
+      {
+        "controller": 0,
+        "note": 39,
+        "cc": -1,
+        "paramId": 55
+      },
+      {
+        "controller": 0,
+        "note": 24,
+        "cc": -1,
+        "paramId": 64
+      },
+      {
+        "controller": 0,
+        "note": 25,
+        "cc": -1,
+        "paramId": 65
+      },
+      {
+        "controller": 0,
+        "note": 26,
+        "cc": -1,
+        "paramId": 66
+      },
+      {
+        "controller": 0,
+        "note": 27,
+        "cc": -1,
+        "paramId": 67
+      },
+      {
+        "controller": 0,
+        "note": 28,
+        "cc": -1,
+        "paramId": 68
+      },
+      {
+        "controller": 0,
+        "note": 29,
+        "cc": -1,
+        "paramId": 69
+      },
+      {
+        "controller": 0,
+        "note": 30,
+        "cc": -1,
+        "paramId": 70
+      },
+      {
+        "controller": 0,
+        "note": 31,
+        "cc": -1,
+        "paramId": 71
+      },
+      {
+        "controller": 0,
+        "note": 16,
+        "cc": -1,
+        "paramId": 80
+      },
+      {
+        "controller": 0,
+        "note": 17,
+        "cc": -1,
+        "paramId": 81
+      },
+      {
+        "controller": 0,
+        "note": 18,
+        "cc": -1,
+        "paramId": 82
+      },
+      {
+        "controller": 0,
+        "note": 19,
+        "cc": -1,
+        "paramId": 83
+      },
+      {
+        "controller": 0,
+        "note": 20,
+        "cc": -1,
+        "paramId": 84
+      },
+      {
+        "controller": 0,
+        "note": 21,
+        "cc": -1,
+        "paramId": 85
+      },
+      {
+        "controller": 0,
+        "note": 22,
+        "cc": -1,
+        "paramId": 86
+      },
+      {
+        "controller": 0,
+        "note": 23,
+        "cc": -1,
+        "paramId": 87
+      },
+      {
+        "controller": 0,
+        "note": 8,
+        "cc": -1,
+        "paramId": 96
+      },
+      {
+        "controller": 0,
+        "note": 9,
+        "cc": -1,
+        "paramId": 97
+      },
+      {
+        "controller": 0,
+        "note": 10,
+        "cc": -1,
+        "paramId": 98
+      },
+      {
+        "controller": 0,
+        "note": 11,
+        "cc": -1,
+        "paramId": 99
+      },
+      {
+        "controller": 0,
+        "note": 12,
+        "cc": -1,
+        "paramId": 100
+      },
+      {
+        "controller": 0,
+        "note": 13,
+        "cc": -1,
+        "paramId": 101
+      },
+      {
+        "controller": 0,
+        "note": 14,
+        "cc": -1,
+        "paramId": 102
+      },
+      {
+        "controller": 0,
+        "note": 15,
+        "cc": -1,
+        "paramId": 103
+      },
+      {
+        "controller": 0,
+        "note": 0,
+        "cc": -1,
+        "paramId": 112
+      },
+      {
+        "controller": 0,
+        "note": 1,
+        "cc": -1,
+        "paramId": 113
+      },
+      {
+        "controller": 0,
+        "note": 2,
+        "cc": -1,
+        "paramId": 114
+      },
+      {
+        "controller": 0,
+        "note": 3,
+        "cc": -1,
+        "paramId": 115
+      },
+      {
+        "controller": 0,
+        "note": 4,
+        "cc": -1,
+        "paramId": 116
+      },
+      {
+        "controller": 0,
+        "note": 5,
+        "cc": -1,
+        "paramId": 117
+      },
+      {
+        "controller": 0,
+        "note": 6,
+        "cc": -1,
+        "paramId": 118
+      },
+      {
+        "controller": 0,
+        "note": 7,
+        "cc": -1,
+        "paramId": 119
+      },
+      {
+        "controller": 1,
+        "note": 56,
+        "cc": -1,
+        "paramId": 8
+      },
+      {
+        "controller": 1,
+        "note": 57,
+        "cc": -1,
+        "paramId": 9
+      },
+      {
+        "controller": 1,
+        "note": 58,
+        "cc": -1,
+        "paramId": 10
+      },
+      {
+        "controller": 1,
+        "note": 59,
+        "cc": -1,
+        "paramId": 11
+      },
+      {
+        "controller": 1,
+        "note": 60,
+        "cc": -1,
+        "paramId": 12
+      },
+      {
+        "controller": 1,
+        "note": 61,
+        "cc": -1,
+        "paramId": 13
+      },
+      {
+        "controller": 1,
+        "note": 62,
+        "cc": -1,
+        "paramId": 14
+      },
+      {
+        "controller": 1,
+        "note": 63,
+        "cc": -1,
+        "paramId": 15
+      },
+      {
+        "controller": 1,
+        "note": 48,
+        "cc": -1,
+        "paramId": 24
+      },
+      {
+        "controller": 1,
+        "note": 49,
+        "cc": -1,
+        "paramId": 25
+      },
+      {
+        "controller": 1,
+        "note": 50,
+        "cc": -1,
+        "paramId": 26
+      },
+      {
+        "controller": 1,
+        "note": 51,
+        "cc": -1,
+        "paramId": 27
+      },
+      {
+        "controller": 1,
+        "note": 52,
+        "cc": -1,
+        "paramId": 28
+      },
+      {
+        "controller": 1,
+        "note": 53,
+        "cc": -1,
+        "paramId": 29
+      },
+      {
+        "controller": 1,
+        "note": 54,
+        "cc": -1,
+        "paramId": 30
+      },
+      {
+        "controller": 1,
+        "note": 55,
+        "cc": -1,
+        "paramId": 31
+      },
+      {
+        "controller": 1,
+        "note": 40,
+        "cc": -1,
+        "paramId": 40
+      },
+      {
+        "controller": 1,
+        "note": 41,
+        "cc": -1,
+        "paramId": 41
+      },
+      {
+        "controller": 1,
+        "note": 42,
+        "cc": -1,
+        "paramId": 42
+      },
+      {
+        "controller": 1,
+        "note": 43,
+        "cc": -1,
+        "paramId": 43
+      },
+      {
+        "controller": 1,
+        "note": 44,
+        "cc": -1,
+        "paramId": 44
+      },
+      {
+        "controller": 1,
+        "note": 45,
+        "cc": -1,
+        "paramId": 45
+      },
+      {
+        "controller": 1,
+        "note": 46,
+        "cc": -1,
+        "paramId": 46
+      },
+      {
+        "controller": 1,
+        "note": 47,
+        "cc": -1,
+        "paramId": 47
+      },
+      {
+        "controller": 1,
+        "note": 32,
+        "cc": -1,
+        "paramId": 56
+      },
+      {
+        "controller": 1,
+        "note": 33,
+        "cc": -1,
+        "paramId": 57
+      },
+      {
+        "controller": 1,
+        "note": 34,
+        "cc": -1,
+        "paramId": 58
+      },
+      {
+        "controller": 1,
+        "note": 35,
+        "cc": -1,
+        "paramId": 59
+      },
+      {
+        "controller": 1,
+        "note": 36,
+        "cc": -1,
+        "paramId": 60
+      },
+      {
+        "controller": 1,
+        "note": 37,
+        "cc": -1,
+        "paramId": 61
+      },
+      {
+        "controller": 1,
+        "note": 38,
+        "cc": -1,
+        "paramId": 62
+      },
+      {
+        "controller": 1,
+        "note": 39,
+        "cc": -1,
+        "paramId": 63
+      },
+      {
+        "controller": 1,
+        "note": 24,
+        "cc": -1,
+        "paramId": 72
+      },
+      {
+        "controller": 1,
+        "note": 25,
+        "cc": -1,
+        "paramId": 73
+      },
+      {
+        "controller": 1,
+        "note": 26,
+        "cc": -1,
+        "paramId": 74
+      },
+      {
+        "controller": 1,
+        "note": 27,
+        "cc": -1,
+        "paramId": 75
+      },
+      {
+        "controller": 1,
+        "note": 28,
+        "cc": -1,
+        "paramId": 76
+      },
+      {
+        "controller": 1,
+        "note": 29,
+        "cc": -1,
+        "paramId": 77
+      },
+      {
+        "controller": 1,
+        "note": 30,
+        "cc": -1,
+        "paramId": 78
+      },
+      {
+        "controller": 1,
+        "note": 31,
+        "cc": -1,
+        "paramId": 79
+      },
+      {
+        "controller": 1,
+        "note": 16,
+        "cc": -1,
+        "paramId": 88
+      },
+      {
+        "controller": 1,
+        "note": 17,
+        "cc": -1,
+        "paramId": 89
+      },
+      {
+        "controller": 1,
+        "note": 18,
+        "cc": -1,
+        "paramId": 90
+      },
+      {
+        "controller": 1,
+        "note": 19,
+        "cc": -1,
+        "paramId": 91
+      },
+      {
+        "controller": 1,
+        "note": 20,
+        "cc": -1,
+        "paramId": 92
+      },
+      {
+        "controller": 1,
+        "note": 21,
+        "cc": -1,
+        "paramId": 93
+      },
+      {
+        "controller": 1,
+        "note": 22,
+        "cc": -1,
+        "paramId": 94
+      },
+      {
+        "controller": 1,
+        "note": 23,
+        "cc": -1,
+        "paramId": 95
+      },
+      {
+        "controller": 1,
+        "note": 8,
+        "cc": -1,
+        "paramId": 104
+      },
+      {
+        "controller": 1,
+        "note": 9,
+        "cc": -1,
+        "paramId": 105
+      },
+      {
+        "controller": 1,
+        "note": 10,
+        "cc": -1,
+        "paramId": 106
+      },
+      {
+        "controller": 1,
+        "note": 11,
+        "cc": -1,
+        "paramId": 107
+      },
+      {
+        "controller": 1,
+        "note": 12,
+        "cc": -1,
+        "paramId": 108
+      },
+      {
+        "controller": 1,
+        "note": 13,
+        "cc": -1,
+        "paramId": 109
+      },
+      {
+        "controller": 1,
+        "note": 14,
+        "cc": -1,
+        "paramId": 110
+      },
+      {
+        "controller": 1,
+        "note": 15,
+        "cc": -1,
+        "paramId": 111
+      },
+      {
+        "controller": 1,
+        "note": 0,
+        "cc": -1,
+        "paramId": 120
+      },
+      {
+        "controller": 1,
+        "note": 1,
+        "cc": -1,
+        "paramId": 121
+      },
+      {
+        "controller": 1,
+        "note": 2,
+        "cc": -1,
+        "paramId": 122
+      },
+      {
+        "controller": 1,
+        "note": 3,
+        "cc": -1,
+        "paramId": 123
+      },
+      {
+        "controller": 1,
+        "note": 4,
+        "cc": -1,
+        "paramId": 124
+      },
+      {
+        "controller": 1,
+        "note": 5,
+        "cc": -1,
+        "paramId": 125
+      },
+      {
+        "controller": 1,
+        "note": 6,
+        "cc": -1,
+        "paramId": 126
+      },
+      {
+        "controller": 1,
+        "note": 7,
+        "cc": -1,
+        "paramId": 127
+      },
+      {
+        "controller": 1,
+        "note": 112,
+        "cc": -1,
+        "paramId": 128
+      },
+      {
+        "controller": 1,
+        "note": 113,
+        "cc": -1,
+        "paramId": 129
+      },
+      {
+        "controller": 1,
+        "note": 114,
+        "cc": -1,
+        "paramId": 130
+      },
+      {
+        "controller": 1,
+        "note": 115,
+        "cc": -1,
+        "paramId": 131
+      },
+      {
+        "controller": 1,
+        "note": 116,
+        "cc": -1,
+        "paramId": 132
+      },
+      {
+        "controller": 1,
+        "note": 117,
+        "cc": -1,
+        "paramId": 133
+      },
+      {
+        "controller": 1,
+        "note": 118,
+        "cc": -1,
+        "paramId": 134
+      },
+      {
+        "controller": 1,
+        "note": 119,
+        "cc": -1,
+        "paramId": 135
+      },
+      {
+        "controller": 1,
+        "note": -1,
+        "cc": 49,
+        "paramId": 161
+      },
+      {
+        "controller": 1,
+        "note": -1,
+        "cc": 50,
+        "paramId": 162
+      },
+      {
+        "controller": 1,
+        "note": -1,
+        "cc": 51,
+        "paramId": 163
+      },
+      {
+        "controller": 1,
+        "note": -1,
+        "cc": 52,
+        "paramId": 164
+      },
+      {
+        "controller": 1,
+        "note": -1,
+        "cc": 53,
+        "paramId": 165
+      },
+      {
+        "controller": 1,
+        "note": -1,
+        "cc": 54,
+        "paramId": 166
+      },
+      {
+        "controller": 1,
+        "note": -1,
+        "cc": 55,
+        "paramId": 167
+      },
+      {
+        "controller": 1,
+        "note": -1,
+        "cc": 48,
+        "paramId": 160
+      }
+    ],
+    "midiInputLeft": {
+      "driver": 1,
+      "channel": -1
+    },
+    "midiInputRight": {
+      "driver": 1,
+      "deviceName": "APC mini mk2 Control",
+      "channel": -1
+    },
+    "midiOutputLeft": {
+      "driver": 1,
+      "channel": 0
+    },
+    "midiOutputRight": {
+      "driver": 1,
+      "deviceName": "APC mini mk2 Control",
+      "channel": 0
+    }
+  }
+}

--- a/presets/IversonJr/Iverson_jr_APC_Mini_Mk2.vcvm
+++ b/presets/IversonJr/Iverson_jr_APC_Mini_Mk2.vcvm
@@ -1,0 +1,1327 @@
+{
+  "plugin": "StudioSixPlusOne",
+  "model": "IversonJr",
+  "version": "2.1.00",
+  "params": [
+    {
+      "value": 0.0,
+      "id": 0
+    },
+    {
+      "value": 0.0,
+      "id": 1
+    },
+    {
+      "value": 0.0,
+      "id": 2
+    },
+    {
+      "value": 0.0,
+      "id": 3
+    },
+    {
+      "value": 0.0,
+      "id": 4
+    },
+    {
+      "value": 0.0,
+      "id": 5
+    },
+    {
+      "value": 0.0,
+      "id": 6
+    },
+    {
+      "value": 0.0,
+      "id": 7
+    },
+    {
+      "value": 0.0,
+      "id": 8
+    },
+    {
+      "value": 0.0,
+      "id": 9
+    },
+    {
+      "value": 0.0,
+      "id": 10
+    },
+    {
+      "value": 0.0,
+      "id": 11
+    },
+    {
+      "value": 0.0,
+      "id": 12
+    },
+    {
+      "value": 0.0,
+      "id": 13
+    },
+    {
+      "value": 0.0,
+      "id": 14
+    },
+    {
+      "value": 0.0,
+      "id": 15
+    },
+    {
+      "value": 0.0,
+      "id": 16
+    },
+    {
+      "value": 0.0,
+      "id": 17
+    },
+    {
+      "value": 0.0,
+      "id": 18
+    },
+    {
+      "value": 0.0,
+      "id": 19
+    },
+    {
+      "value": 0.0,
+      "id": 20
+    },
+    {
+      "value": 0.0,
+      "id": 21
+    },
+    {
+      "value": 0.0,
+      "id": 22
+    },
+    {
+      "value": 0.0,
+      "id": 23
+    },
+    {
+      "value": 0.0,
+      "id": 24
+    },
+    {
+      "value": 0.0,
+      "id": 25
+    },
+    {
+      "value": 0.0,
+      "id": 26
+    },
+    {
+      "value": 0.0,
+      "id": 27
+    },
+    {
+      "value": 0.0,
+      "id": 28
+    },
+    {
+      "value": 0.0,
+      "id": 29
+    },
+    {
+      "value": 0.0,
+      "id": 30
+    },
+    {
+      "value": 0.0,
+      "id": 31
+    },
+    {
+      "value": 0.0,
+      "id": 32
+    },
+    {
+      "value": 0.0,
+      "id": 33
+    },
+    {
+      "value": 0.0,
+      "id": 34
+    },
+    {
+      "value": 0.0,
+      "id": 35
+    },
+    {
+      "value": 0.0,
+      "id": 36
+    },
+    {
+      "value": 0.0,
+      "id": 37
+    },
+    {
+      "value": 0.0,
+      "id": 38
+    },
+    {
+      "value": 0.0,
+      "id": 39
+    },
+    {
+      "value": 0.0,
+      "id": 40
+    },
+    {
+      "value": 0.0,
+      "id": 41
+    },
+    {
+      "value": 0.0,
+      "id": 42
+    },
+    {
+      "value": 0.0,
+      "id": 43
+    },
+    {
+      "value": 0.0,
+      "id": 44
+    },
+    {
+      "value": 0.0,
+      "id": 45
+    },
+    {
+      "value": 0.0,
+      "id": 46
+    },
+    {
+      "value": 0.0,
+      "id": 47
+    },
+    {
+      "value": 0.0,
+      "id": 48
+    },
+    {
+      "value": 0.0,
+      "id": 49
+    },
+    {
+      "value": 0.0,
+      "id": 50
+    },
+    {
+      "value": 0.0,
+      "id": 51
+    },
+    {
+      "value": 0.0,
+      "id": 52
+    },
+    {
+      "value": 0.0,
+      "id": 53
+    },
+    {
+      "value": 0.0,
+      "id": 54
+    },
+    {
+      "value": 0.0,
+      "id": 55
+    },
+    {
+      "value": 0.0,
+      "id": 56
+    },
+    {
+      "value": 0.0,
+      "id": 57
+    },
+    {
+      "value": 0.0,
+      "id": 58
+    },
+    {
+      "value": 0.0,
+      "id": 59
+    },
+    {
+      "value": 0.0,
+      "id": 60
+    },
+    {
+      "value": 0.0,
+      "id": 61
+    },
+    {
+      "value": 0.0,
+      "id": 62
+    },
+    {
+      "value": 0.0,
+      "id": 63
+    },
+    {
+      "value": 0.0,
+      "id": 64
+    },
+    {
+      "value": 0.0,
+      "id": 65
+    },
+    {
+      "value": 0.0,
+      "id": 66
+    },
+    {
+      "value": 0.0,
+      "id": 67
+    },
+    {
+      "value": 0.0,
+      "id": 68
+    },
+    {
+      "value": 0.0,
+      "id": 69
+    },
+    {
+      "value": 0.0,
+      "id": 70
+    },
+    {
+      "value": 0.0,
+      "id": 71
+    },
+    {
+      "value": 0.0,
+      "id": 72
+    },
+    {
+      "value": 0.0,
+      "id": 73
+    },
+    {
+      "value": 0.0,
+      "id": 74
+    },
+    {
+      "value": 0.0,
+      "id": 75
+    },
+    {
+      "value": 0.0,
+      "id": 76
+    },
+    {
+      "value": 0.0,
+      "id": 77
+    },
+    {
+      "value": 0.0,
+      "id": 78
+    },
+    {
+      "value": 0.0,
+      "id": 79
+    },
+    {
+      "value": 0.0,
+      "id": 80
+    },
+    {
+      "value": 0.0,
+      "id": 81
+    },
+    {
+      "value": 0.0,
+      "id": 82
+    },
+    {
+      "value": 0.0,
+      "id": 83
+    },
+    {
+      "value": 0.0,
+      "id": 84
+    },
+    {
+      "value": 0.0,
+      "id": 85
+    },
+    {
+      "value": 0.0,
+      "id": 86
+    },
+    {
+      "value": 0.0,
+      "id": 87
+    },
+    {
+      "value": 0.0,
+      "id": 88
+    },
+    {
+      "value": 0.0,
+      "id": 89
+    },
+    {
+      "value": 0.0,
+      "id": 90
+    },
+    {
+      "value": 0.0,
+      "id": 91
+    },
+    {
+      "value": 0.0,
+      "id": 92
+    },
+    {
+      "value": 0.0,
+      "id": 93
+    },
+    {
+      "value": 0.0,
+      "id": 94
+    },
+    {
+      "value": 0.0,
+      "id": 95
+    },
+    {
+      "value": 0.0,
+      "id": 96
+    },
+    {
+      "value": 0.0,
+      "id": 97
+    },
+    {
+      "value": 0.0,
+      "id": 98
+    },
+    {
+      "value": 0.0,
+      "id": 99
+    },
+    {
+      "value": 0.0,
+      "id": 100
+    },
+    {
+      "value": 0.0,
+      "id": 101
+    },
+    {
+      "value": 0.0,
+      "id": 102
+    },
+    {
+      "value": 0.0,
+      "id": 103
+    },
+    {
+      "value": 0.0,
+      "id": 104
+    },
+    {
+      "value": 0.0,
+      "id": 105
+    },
+    {
+      "value": 0.0,
+      "id": 106
+    },
+    {
+      "value": 0.0,
+      "id": 107
+    },
+    {
+      "value": 0.0,
+      "id": 108
+    },
+    {
+      "value": 0.0,
+      "id": 109
+    },
+    {
+      "value": 0.0,
+      "id": 110
+    },
+    {
+      "value": 0.0,
+      "id": 111
+    },
+    {
+      "value": 0.0,
+      "id": 112
+    },
+    {
+      "value": 0.0,
+      "id": 113
+    },
+    {
+      "value": 0.0,
+      "id": 114
+    },
+    {
+      "value": 0.0,
+      "id": 115
+    },
+    {
+      "value": 0.0,
+      "id": 116
+    },
+    {
+      "value": 0.0,
+      "id": 117
+    },
+    {
+      "value": 0.0,
+      "id": 118
+    },
+    {
+      "value": 0.0,
+      "id": 119
+    },
+    {
+      "value": 0.0,
+      "id": 120
+    },
+    {
+      "value": 0.0,
+      "id": 121
+    },
+    {
+      "value": 0.0,
+      "id": 122
+    },
+    {
+      "value": 0.0,
+      "id": 123
+    },
+    {
+      "value": 0.0,
+      "id": 124
+    },
+    {
+      "value": 0.0,
+      "id": 125
+    },
+    {
+      "value": 0.0,
+      "id": 126
+    },
+    {
+      "value": 0.0,
+      "id": 127
+    },
+    {
+      "value": 0.0,
+      "id": 128
+    },
+    {
+      "value": 0.0,
+      "id": 129
+    },
+    {
+      "value": 0.0,
+      "id": 130
+    },
+    {
+      "value": 0.0,
+      "id": 131
+    },
+    {
+      "value": 0.0,
+      "id": 132
+    },
+    {
+      "value": 0.0,
+      "id": 133
+    },
+    {
+      "value": 0.0,
+      "id": 134
+    },
+    {
+      "value": 0.0,
+      "id": 135
+    },
+    {
+      "value": 8.0,
+      "id": 136
+    },
+    {
+      "value": 8.0,
+      "id": 137
+    },
+    {
+      "value": 8.0,
+      "id": 138
+    },
+    {
+      "value": 8.0,
+      "id": 139
+    },
+    {
+      "value": 8.0,
+      "id": 140
+    },
+    {
+      "value": 8.0,
+      "id": 141
+    },
+    {
+      "value": 8.0,
+      "id": 142
+    },
+    {
+      "value": 8.0,
+      "id": 143
+    },
+    {
+      "value": 0.0,
+      "id": 144
+    },
+    {
+      "value": 0.0,
+      "id": 145
+    },
+    {
+      "value": 0.0,
+      "id": 146
+    },
+    {
+      "value": 0.0,
+      "id": 147
+    },
+    {
+      "value": 0.0,
+      "id": 148
+    },
+    {
+      "value": 0.0,
+      "id": 149
+    },
+    {
+      "value": 0.0,
+      "id": 150
+    },
+    {
+      "value": 0.0,
+      "id": 151
+    },
+    {
+      "value": 0.0,
+      "id": 152
+    },
+    {
+      "value": 0.0,
+      "id": 153
+    },
+    {
+      "value": 0.0,
+      "id": 154
+    },
+    {
+      "value": 0.0,
+      "id": 155
+    },
+    {
+      "value": 0.0,
+      "id": 156
+    },
+    {
+      "value": 0.0,
+      "id": 157
+    },
+    {
+      "value": 0.0,
+      "id": 158
+    },
+    {
+      "value": 0.0,
+      "id": 159
+    },
+    {
+      "value": 0.0,
+      "id": 160
+    },
+    {
+      "value": 0.0,
+      "id": 161
+    },
+    {
+      "value": 0.0,
+      "id": 162
+    },
+    {
+      "value": 0.0,
+      "id": 163
+    },
+    {
+      "value": 0.0,
+      "id": 164
+    },
+    {
+      "value": 0.0,
+      "id": 165
+    },
+    {
+      "value": 0.0,
+      "id": 166
+    },
+    {
+      "value": 0.0,
+      "id": 167
+    },
+    {
+      "value": 0.0,
+      "id": 168
+    },
+    {
+      "value": 0.0,
+      "id": 169
+    },
+    {
+      "value": 0.0,
+      "id": 170
+    },
+    {
+      "value": 21.0,
+      "id": 171
+    },
+    {
+      "value": 5.0,
+      "id": 172
+    },
+    {
+      "value": 5.0,
+      "id": 173
+    },
+    {
+      "value": 96.0,
+      "id": 174
+    },
+    {
+      "value": 0.0,
+      "id": 175
+    },
+    {
+      "value": 0.0,
+      "id": 176
+    },
+    {
+      "value": 0.0,
+      "id": 177
+    },
+    {
+      "value": 0.0,
+      "id": 178
+    }
+  ],
+  "data": {
+    "actives": [
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true
+    ],
+    "lengths": [
+      8,
+      8,
+      8,
+      8,
+      8,
+      8,
+      8,
+      8
+    ],
+    "index": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "sequenceHi": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "sequenceLow": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "midiBinding": [
+      {
+        "controller": 0,
+        "note": 57,
+        "cc": -1,
+        "paramId": 1
+      },
+      {
+        "controller": 0,
+        "note": 58,
+        "cc": -1,
+        "paramId": 2
+      },
+      {
+        "controller": 0,
+        "note": 59,
+        "cc": -1,
+        "paramId": 3
+      },
+      {
+        "controller": 0,
+        "note": 60,
+        "cc": -1,
+        "paramId": 4
+      },
+      {
+        "controller": 0,
+        "note": 61,
+        "cc": -1,
+        "paramId": 5
+      },
+      {
+        "controller": 0,
+        "note": 62,
+        "cc": -1,
+        "paramId": 6
+      },
+      {
+        "controller": 0,
+        "note": 63,
+        "cc": -1,
+        "paramId": 7
+      },
+      {
+        "controller": 0,
+        "note": 49,
+        "cc": -1,
+        "paramId": 9
+      },
+      {
+        "controller": 0,
+        "note": 50,
+        "cc": -1,
+        "paramId": 10
+      },
+      {
+        "controller": 0,
+        "note": 51,
+        "cc": -1,
+        "paramId": 11
+      },
+      {
+        "controller": 0,
+        "note": 52,
+        "cc": -1,
+        "paramId": 12
+      },
+      {
+        "controller": 0,
+        "note": 53,
+        "cc": -1,
+        "paramId": 13
+      },
+      {
+        "controller": 0,
+        "note": 54,
+        "cc": -1,
+        "paramId": 14
+      },
+      {
+        "controller": 0,
+        "note": 55,
+        "cc": -1,
+        "paramId": 15
+      },
+      {
+        "controller": 0,
+        "note": 41,
+        "cc": -1,
+        "paramId": 17
+      },
+      {
+        "controller": 0,
+        "note": 42,
+        "cc": -1,
+        "paramId": 18
+      },
+      {
+        "controller": 0,
+        "note": 43,
+        "cc": -1,
+        "paramId": 19
+      },
+      {
+        "controller": 0,
+        "note": 44,
+        "cc": -1,
+        "paramId": 20
+      },
+      {
+        "controller": 0,
+        "note": 45,
+        "cc": -1,
+        "paramId": 21
+      },
+      {
+        "controller": 0,
+        "note": 46,
+        "cc": -1,
+        "paramId": 22
+      },
+      {
+        "controller": 0,
+        "note": 47,
+        "cc": -1,
+        "paramId": 23
+      },
+      {
+        "controller": 0,
+        "note": 33,
+        "cc": -1,
+        "paramId": 25
+      },
+      {
+        "controller": 0,
+        "note": 34,
+        "cc": -1,
+        "paramId": 26
+      },
+      {
+        "controller": 0,
+        "note": 35,
+        "cc": -1,
+        "paramId": 27
+      },
+      {
+        "controller": 0,
+        "note": 36,
+        "cc": -1,
+        "paramId": 28
+      },
+      {
+        "controller": 0,
+        "note": 37,
+        "cc": -1,
+        "paramId": 29
+      },
+      {
+        "controller": 0,
+        "note": 38,
+        "cc": -1,
+        "paramId": 30
+      },
+      {
+        "controller": 0,
+        "note": 39,
+        "cc": -1,
+        "paramId": 31
+      },
+      {
+        "controller": 0,
+        "note": 25,
+        "cc": -1,
+        "paramId": 33
+      },
+      {
+        "controller": 0,
+        "note": 26,
+        "cc": -1,
+        "paramId": 34
+      },
+      {
+        "controller": 0,
+        "note": 27,
+        "cc": -1,
+        "paramId": 35
+      },
+      {
+        "controller": 0,
+        "note": 28,
+        "cc": -1,
+        "paramId": 36
+      },
+      {
+        "controller": 0,
+        "note": 29,
+        "cc": -1,
+        "paramId": 37
+      },
+      {
+        "controller": 0,
+        "note": 30,
+        "cc": -1,
+        "paramId": 38
+      },
+      {
+        "controller": 0,
+        "note": 31,
+        "cc": -1,
+        "paramId": 39
+      },
+      {
+        "controller": 0,
+        "note": 17,
+        "cc": -1,
+        "paramId": 41
+      },
+      {
+        "controller": 0,
+        "note": 18,
+        "cc": -1,
+        "paramId": 42
+      },
+      {
+        "controller": 0,
+        "note": 19,
+        "cc": -1,
+        "paramId": 43
+      },
+      {
+        "controller": 0,
+        "note": 20,
+        "cc": -1,
+        "paramId": 44
+      },
+      {
+        "controller": 0,
+        "note": 21,
+        "cc": -1,
+        "paramId": 45
+      },
+      {
+        "controller": 0,
+        "note": 22,
+        "cc": -1,
+        "paramId": 46
+      },
+      {
+        "controller": 0,
+        "note": 23,
+        "cc": -1,
+        "paramId": 47
+      },
+      {
+        "controller": 0,
+        "note": 9,
+        "cc": -1,
+        "paramId": 49
+      },
+      {
+        "controller": 0,
+        "note": 10,
+        "cc": -1,
+        "paramId": 50
+      },
+      {
+        "controller": 0,
+        "note": 11,
+        "cc": -1,
+        "paramId": 51
+      },
+      {
+        "controller": 0,
+        "note": 12,
+        "cc": -1,
+        "paramId": 52
+      },
+      {
+        "controller": 0,
+        "note": 13,
+        "cc": -1,
+        "paramId": 53
+      },
+      {
+        "controller": 0,
+        "note": 14,
+        "cc": -1,
+        "paramId": 54
+      },
+      {
+        "controller": 0,
+        "note": 15,
+        "cc": -1,
+        "paramId": 55
+      },
+      {
+        "controller": 0,
+        "note": 1,
+        "cc": -1,
+        "paramId": 57
+      },
+      {
+        "controller": 0,
+        "note": 2,
+        "cc": -1,
+        "paramId": 58
+      },
+      {
+        "controller": 0,
+        "note": 3,
+        "cc": -1,
+        "paramId": 59
+      },
+      {
+        "controller": 0,
+        "note": 4,
+        "cc": -1,
+        "paramId": 60
+      },
+      {
+        "controller": 0,
+        "note": 5,
+        "cc": -1,
+        "paramId": 61
+      },
+      {
+        "controller": 0,
+        "note": 6,
+        "cc": -1,
+        "paramId": 62
+      },
+      {
+        "controller": 0,
+        "note": 7,
+        "cc": -1,
+        "paramId": 63
+      },
+      {
+        "controller": 0,
+        "note": -1,
+        "cc": 48,
+        "paramId": 152
+      },
+      {
+        "controller": 0,
+        "note": -1,
+        "cc": 49,
+        "paramId": 153
+      },
+      {
+        "controller": 0,
+        "note": -1,
+        "cc": 50,
+        "paramId": 154
+      },
+      {
+        "controller": 0,
+        "note": -1,
+        "cc": 51,
+        "paramId": 155
+      },
+      {
+        "controller": 0,
+        "note": -1,
+        "cc": 52,
+        "paramId": 156
+      },
+      {
+        "controller": 0,
+        "note": -1,
+        "cc": 53,
+        "paramId": 157
+      },
+      {
+        "controller": 0,
+        "note": -1,
+        "cc": 54,
+        "paramId": 158
+      },
+      {
+        "controller": 0,
+        "note": -1,
+        "cc": 55,
+        "paramId": 159
+      },
+      {
+        "controller": 0,
+        "note": 100,
+        "cc": -1,
+        "paramId": 144
+      },
+      {
+        "controller": 0,
+        "note": 101,
+        "cc": -1,
+        "paramId": 145
+      },
+      {
+        "controller": 0,
+        "note": 102,
+        "cc": -1,
+        "paramId": 146
+      },
+      {
+        "controller": 0,
+        "note": 103,
+        "cc": -1,
+        "paramId": 147
+      },
+      {
+        "controller": 0,
+        "note": 104,
+        "cc": -1,
+        "paramId": 150
+      },
+      {
+        "controller": 0,
+        "note": 105,
+        "cc": -1,
+        "paramId": 148
+      },
+      {
+        "controller": 0,
+        "note": 106,
+        "cc": -1,
+        "paramId": 149
+      },
+      {
+        "controller": 0,
+        "note": 107,
+        "cc": -1,
+        "paramId": 177
+      },
+      {
+        "controller": 0,
+        "note": 122,
+        "cc": -1,
+        "paramId": 176
+      },
+      {
+        "controller": 0,
+        "note": 112,
+        "cc": -1,
+        "paramId": 128
+      },
+      {
+        "controller": 0,
+        "note": 113,
+        "cc": -1,
+        "paramId": 129
+      },
+      {
+        "controller": 0,
+        "note": 114,
+        "cc": -1,
+        "paramId": 130
+      },
+      {
+        "controller": 0,
+        "note": 115,
+        "cc": -1,
+        "paramId": 131
+      },
+      {
+        "controller": 0,
+        "note": 116,
+        "cc": -1,
+        "paramId": 132
+      },
+      {
+        "controller": 0,
+        "note": 117,
+        "cc": -1,
+        "paramId": 133
+      },
+      {
+        "controller": 0,
+        "note": 118,
+        "cc": -1,
+        "paramId": 134
+      },
+      {
+        "controller": 0,
+        "note": 119,
+        "cc": -1,
+        "paramId": 135
+      },
+      {
+        "controller": 0,
+        "note": 56,
+        "cc": -1,
+        "paramId": 0
+      },
+      {
+        "controller": 0,
+        "note": 48,
+        "cc": -1,
+        "paramId": 8
+      },
+      {
+        "controller": 0,
+        "note": 40,
+        "cc": -1,
+        "paramId": 16
+      },
+      {
+        "controller": 0,
+        "note": 32,
+        "cc": -1,
+        "paramId": 24
+      },
+      {
+        "controller": 0,
+        "note": 24,
+        "cc": -1,
+        "paramId": 32
+      },
+      {
+        "controller": 0,
+        "note": 16,
+        "cc": -1,
+        "paramId": 40
+      },
+      {
+        "controller": 0,
+        "note": 8,
+        "cc": -1,
+        "paramId": 48
+      },
+      {
+        "controller": 0,
+        "note": 0,
+        "cc": -1,
+        "paramId": 56
+      }
+    ],
+    "midiInputLeft": {
+      "driver": 1,
+      "channel": -1
+    },
+    "midiInputRight": {
+      "driver": 1,
+      "channel": -1
+    },
+    "midiOutputLeft": {
+      "driver": 1,
+      "channel": 0
+    },
+    "midiOutputRight": {
+      "driver": 1,
+      "channel": 0
+    }
+  }
+}


### PR DESCRIPTION
The forum post https://forum.4ms.info/t/studio-six-plus-one-plugins/1618/8 asks about the use of the usb port on the metamodule for connecting midi controllers. I am unable to answer that question.

It is also asked if the presets for the APC Mini Mk II controller are available for use with Iverson, the drum sequencer.
This pull request contains presets for both Iverson and Iverson Jr, but will only be of use if a MIDI controller can be connected.

